### PR TITLE
Migrate to simple jwt and change password

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -10,6 +10,7 @@ import calendar
 
 # Django imports.
 from django.db import transaction
+from django.contrib.auth import get_user_model, authenticate
 
 # Rest Framework imports.
 from rest_framework import serializers
@@ -18,6 +19,7 @@ from rest_framework import serializers
 
 # local imports.
 from accounts.models import User, Projects
+
 
 
 class UserCreateSerializer(serializers.ModelSerializer):
@@ -47,7 +49,15 @@ class UserListSerializer(serializers.ModelSerializer):
         model = User
         fields = ('id', 'first_name', 'last_name', 'email', 'role')
 
-
+class UserLoginSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True)
+    
+    class Meta:
+        model = User
+        fields = ['email', 'password']
+        extra_kwargs = {'password': {'write_only': True}}
+        
+        
 class ProjectsCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -58,9 +68,13 @@ class ProjectsCreateSerializer(serializers.ModelSerializer):
         user = User.objects.get(pk=validated_data.pop('user'))
         return Projects.objects.create(**validated_data,user=user)
 
-
 class ProjectsListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Projects
         fields = ('id', 'project_name', 'user')
+        
+class ChangePasswordSerializer(serializers.Serializer):
+    old_password = serializers.CharField(required=True)
+    new_password = serializers.CharField(required=True)
+    

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -13,23 +13,21 @@ from django.urls import path,include
 
 # local imports.
 from accounts.views import (
-                          TestAppAPIView, 
-                          UserAPIView, 
-                          ProjectAPIView, 
                           RegistrationAPIView,
+                          UserAPIView,
                           LoginView,
-                          LogoutView
+                          LogoutView,
+                          ChangePasswordView,
                           )
 
 app_name = 'accounts'
 
 urlpatterns = [
-    path('test/', TestAppAPIView.as_view(), name='accounts'),
     path('register/', RegistrationAPIView.as_view(), name='register-api'),
     path('login/', LoginView.as_view(), name='login-api'),
     path('logout/', LogoutView.as_view(), name='logout-api'),
+    path('change-password/', ChangePasswordView.as_view(), name='change-password-api'),
     path('list/users/', UserAPIView.as_view(), name='user-api'),
-    path('project/', ProjectAPIView.as_view(), name='project-api'),
     path('students/', include("students.urls", namespace="accounts-students-api")),
     path('employers/',include("employers.urls", namespace="employers-students-api")),
 ]

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,21 +1,19 @@
-from rest_framework_jwt.settings import api_settings
 from rest_framework_jwt.utils import jwt_decode_handler
 from rest_framework_simplejwt.tokens import AccessToken
 
 
 def generate_jwt_token(user, data):
-    # jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
-    # jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
-    # payload = jwt_payload_handler(user)
-    # token = jwt_encode_handler(payload)
-    # data['token'] = token
-    
     data['token'] = str(AccessToken.for_user(user))
     return data
 
+
 def validate_access_token(access_token):
+    """
+    Deprecated: This function is no longer supported and should not be used.
+    Instead, re-implement this using simplejwt.
+    """
     try:
-        token = jwt_decode_handler(access_token)
+        _ = jwt_decode_handler(access_token)
         return True
     except Exception:
         return False

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,5 +1,8 @@
 from rest_framework_jwt.utils import jwt_decode_handler
 from rest_framework_simplejwt.tokens import AccessToken
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import Token
+from accounts.models import User
 
 
 def generate_jwt_token(user, data):
@@ -17,10 +20,21 @@ def validate_access_token(access_token):
         return True
     except Exception:
         return False
-    
+
+
 def get_user_id_from_token(access_token: str):
     return get_user(access_token)['user_id']
+
 
 def get_user(access_token: str):
     return AccessToken(access_token)
 
+
+def get_user_from_header(header):
+    _, token = header['Authorization'].split()
+    user_id = get_user_id_from_token(token)
+    print(user_id)
+    # Get the user object from the user_id
+    User = get_user_model()
+    user = User.objects.get(pk=user_id)
+    return user

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,5 +1,11 @@
 from rest_framework_jwt.settings import api_settings
 from rest_framework_jwt.utils import jwt_decode_handler
+
+
+
+
+
+
 def generate_jwt_token(user, data):
     jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
     jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -21,7 +21,8 @@ def validate_access_token(access_token):
         return False
     
 def get_user_id_from_token(access_token: str):
-    return get_user(access_token)['id']
+    return get_user(access_token)['user_id']
 
 def get_user(access_token: str):
     return AccessToken(access_token)
+

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -4,8 +4,6 @@ from rest_framework_jwt.utils import jwt_decode_handler
 
 
 
-
-
 def generate_jwt_token(user, data):
     jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
     jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,15 +1,16 @@
 from rest_framework_jwt.settings import api_settings
 from rest_framework_jwt.utils import jwt_decode_handler
-
-
+from rest_framework_simplejwt.tokens import AccessToken
 
 
 def generate_jwt_token(user, data):
-    jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
-    jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
-    payload = jwt_payload_handler(user)
-    token = jwt_encode_handler(payload)
-    data['token'] = token
+    # jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
+    # jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
+    # payload = jwt_payload_handler(user)
+    # token = jwt_encode_handler(payload)
+    # data['token'] = token
+    
+    data['token'] = str(AccessToken.for_user(user))
     return data
 
 def validate_access_token(access_token):
@@ -19,7 +20,8 @@ def validate_access_token(access_token):
     except Exception:
         return False
     
-def get_user_id_from_token(access_token):
-    token = jwt_decode_handler(access_token)
-    user_id = token['user_id']
-    return user_id
+def get_user_id_from_token(access_token: str):
+    return get_user(access_token)['id']
+
+def get_user(access_token: str):
+    return AccessToken(access_token)

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,8 +1,6 @@
 from rest_framework_jwt.utils import jwt_decode_handler
 from rest_framework_simplejwt.tokens import AccessToken
 from django.contrib.auth import get_user_model
-from rest_framework_simplejwt.tokens import Token
-from accounts.models import User
 
 
 def generate_jwt_token(user, data):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 from rest_framework.generics import GenericAPIView, CreateAPIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+# jwt
 from rest_framework_jwt.serializers import JSONWebTokenSerializer
 from rest_framework_jwt.views import JSONWebTokenAPIView
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -26,7 +26,7 @@ from accounts.serializers import (UserCreateSerializer,
                                   ProjectsListSerializer,
                                   ChangePasswordSerializer,
                                   UserLoginSerializer)
-from accounts.utils import generate_jwt_token, get_user_id_from_token, get_user
+from accounts.utils import generate_jwt_token, get_user, get_user_from_header
 from accounts.tasks import add
 # Create your views here.
 
@@ -125,8 +125,9 @@ class LogoutView(APIView):
         try:
             user = request.user
             print(user)
-            print(get_user(request.headers['Authorization']))
-            logout(request) #doesn't really delete the accesstoken from the server but rather remove it from client's request header.
+            print(get_user_from_header(request.headers))
+            # doesn't really delete the accesstoken from the server but rather remove it from client's request header.
+            logout(request)
             return Response({'status': True,
                              'message': "logout successfully"},
                             status=status.HTTP_200_OK)
@@ -137,6 +138,7 @@ class LogoutView(APIView):
 
 class ChangePasswordView(APIView):
     http_method_names = ['put']
+
     @swagger_auto_schema(
         security=[{'Bearer': []}],
         operation_description="Change Password API",
@@ -152,13 +154,11 @@ class ChangePasswordView(APIView):
             200: openapi.Response('Success', openapi.Schema(type=openapi.TYPE_OBJECT)),
             400: openapi.Response('Bad request', openapi.Schema(type=openapi.TYPE_OBJECT)),
         },
-        
+
     )
-    def put(self, request, *args, **kwargs):
+    def put(self,  request, *args, **kwargs):
         serializer = ChangePasswordSerializer(data=request.data)
-        print(request.user)
-        print(request.headers)
-        print(request.headers['Authorization'])
+        print(get_user_from_header(request.headers))
         if serializer.is_valid():
             # Check old password
             if not request.user.check_password(serializer.data.get('old_password')):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -117,8 +117,6 @@ class LoginView(CreateAPIView):
 
 
 class LogoutView(APIView):
-    # permission_classes = (IsAuthenticated,)
-
     @staticmethod
     def post(request):
         """
@@ -128,7 +126,7 @@ class LogoutView(APIView):
             user = request.user
             print(user)
             print(get_user(request.headers['Authorization']))
-            logout(request)
+            logout(request) #doesn't really delete the accesstoken from the server but rather remove it from client's request header.
             return Response({'status': True,
                              'message': "logout successfully"},
                             status=status.HTTP_200_OK)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -12,10 +12,6 @@ from rest_framework.views import APIView
 from rest_framework.generics import GenericAPIView, CreateAPIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-# jwt
-from rest_framework_jwt.serializers import JSONWebTokenSerializer
-from rest_framework_jwt.views import JSONWebTokenAPIView
-from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 # simplejwt
 from rest_framework_simplejwt.tokens import AccessToken
 # swagger
@@ -143,9 +139,8 @@ class LogoutView(APIView):
 
 class ChangePasswordView(APIView):
     http_method_names = ['put']
-    authentication_classes = [JSONWebTokenAuthentication]
-
     @swagger_auto_schema(
+        security=[{'Bearer': []}],
         operation_description="Change Password API",
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
@@ -158,13 +153,14 @@ class ChangePasswordView(APIView):
         responses={
             200: openapi.Response('Success', openapi.Schema(type=openapi.TYPE_OBJECT)),
             400: openapi.Response('Bad request', openapi.Schema(type=openapi.TYPE_OBJECT)),
-        }
+        },
+        
     )
     def put(self, request, *args, **kwargs):
         serializer = ChangePasswordSerializer(data=request.data)
         print(request.user)
         print(request.headers)
-        print(get_user_id_from_token(request.headers['Authorization']))
+        print(request.headers['Authorization'])
         if serializer.is_valid():
             # Check old password
             if not request.user.check_password(serializer.data.get('old_password')):

--- a/boilerplate/settings.py
+++ b/boilerplate/settings.py
@@ -93,14 +93,14 @@ WSGI_APPLICATION = 'boilerplate.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ['POSTGRES_NAME'],
-        'USER': os.environ['POSTGRES_USER'],
-        'PASSWORD': os.environ['POSTGRES_PASSWORD'],
-        'HOST': 'localhost',
-        'PORT': '5432',
-        # 'ENGINE': 'django.db.backends.sqlite3',
-        # 'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        # 'ENGINE': 'django.db.backends.postgresql',
+        # 'NAME': os.environ['POSTGRES_NAME'],
+        # 'USER': os.environ['POSTGRES_USER'],
+        # 'PASSWORD': os.environ['POSTGRES_PASSWORD'],
+        # 'HOST': 'localhost',
+        # 'PORT': '5432',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
 

--- a/boilerplate/settings.py
+++ b/boilerplate/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import os
 import datetime
 import environ
+from datetime import timedelta
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -46,6 +47,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt',
     'drf_yasg',
     'ckeditor',
+    'coreapi',
     # Apps
     'job',
     'advisors',
@@ -54,6 +56,7 @@ INSTALLED_APPS = [
     'employers',
     'companies',
     'schools',
+    
 ]
 
 MIDDLEWARE = [
@@ -125,6 +128,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated'
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
@@ -149,19 +153,55 @@ USE_L10N = True
 
 USE_TZ = True
 
-JWT_AUTH = {
-    'JWT_VERIFY_EXPIRATION': True,
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(days=1),
-    'JWT_ALLOW_REFRESH': False,
-    'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
-    'JWT_AUTH_HEADER_PREFIX': 'token',
+# JWT_AUTH = {
+#     'JWT_VERIFY_EXPIRATION': True,
+#     'JWT_EXPIRATION_DELTA': datetime.timedelta(days=1),
+#     'JWT_ALLOW_REFRESH': False,
+#     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
+#     'JWT_AUTH_HEADER_PREFIX': 'token',
+# }
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=30),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'ROTATE_REFRESH_TOKENS': False,
+    'BLACKLIST_AFTER_ROTATION': False,
+    'UPDATE_LAST_LOGIN': False,
+
+    'ALGORITHM': 'HS256',
+    'SIGNING_KEY': SECRET_KEY,
+    'VERIFYING_KEY': None,
+    'AUDIENCE': None,
+    'ISSUER': None,
+    'JWK_URL': None,
+    'LEEWAY': 0,
+
+    'AUTH_HEADER_TYPES': ('Bearer',),
+    'AUTH_HEADER_NAME': 'HTTP_AUTHORIZATION',
+    'USER_ID_FIELD': 'id',
+    'USER_ID_CLAIM': 'user_id',
+    'USER_AUTHENTICATION_RULE': 'rest_framework_simplejwt.authentication.default_user_authentication_rule',
+
+    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
+    'TOKEN_TYPE_CLAIM': 'token_type',
+    'TOKEN_USER_CLASS': 'rest_framework_simplejwt.models.TokenUser',
+
+    'JTI_CLAIM': 'jti',
+
+    'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
+    'SLIDING_TOKEN_LIFETIME': timedelta(minutes=5),
+    'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
 }
 
 
 # Configuration for Swagger
 SWAGGER_SETTINGS = {
     "SECURITY_DEFINITIONS": {
-        "JWT": {"type": "apiKey", "name": "Authorization", "in": "header"}
+        'Bearer': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header'
+        },
     }
 }
 

--- a/boilerplate/settings.py
+++ b/boilerplate/settings.py
@@ -127,7 +127,6 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        # 'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework.metadata.SimpleMetadata',

--- a/boilerplate/settings.py
+++ b/boilerplate/settings.py
@@ -128,7 +128,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated'
+        # dont fucking set this. This is for authorization in django view, why we are using swagger ui.
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,4 +83,4 @@ botocore<1.28.0,>=1.27.78
 s3transfer<0.7.0,>=0.6.0
 django-ckeditor
 # django-environ
-djangorestframework-simplejwt
+# djangorestframework-simplejwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,3 +83,4 @@ botocore<1.28.0,>=1.27.78
 s3transfer<0.7.0,>=0.6.0
 django-ckeditor
 # django-environ
+djangorestframework-simplejwt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -87,7 +87,7 @@ Django<4
 django-filter==21.1
 django-log-request-id==2.0.0
 djangorestframework>=3.13.1,!=3.14.0
-djangorestframework-jwt==1.11.0
+# djangorestframework-jwt==1.11.0
 djangorestframework-simplejwt
 # docutils==0.18.1
 drf-yasg==1.20.0

--- a/students/models.py
+++ b/students/models.py
@@ -1,6 +1,7 @@
 from django.utils.translation import gettext_lazy as _
 from django.db import models
 from schools.models import School
+
 # Create your models here.
 
 class Student(models.Model):

--- a/students/models.py
+++ b/students/models.py
@@ -9,4 +9,3 @@ class Student(models.Model):
     email = models.EmailField(_('email address'), unique=True)
     school = models.ForeignKey(School, on_delete=models.SET_NULL, null=True)
     
-  


### PR DESCRIPTION
# Moving to simple JWT
Done, but Swagger is still having some problems including a Bearer header (there is no Bearer prefix in the authorization header now, so we will get an AnonynousUser when calling APIs that requires Bearer header).
Instead, I provide an alternative way to call APIs that require authorization.
1. Login/Register and copy the access token:    
![image](https://user-images.githubusercontent.com/52169024/211260805-0b39436f-8ddc-4c76-8946-3241e6a58223.png)    
2.  Go to the API you want to call, F.e change-password.  Then put the access token obtained in the lock icon. Click execute.  
3. This will result in an error since the server cannot identify the swagger request without the Bearer. You will have to copy the curl:    
![image](https://user-images.githubusercontent.com/52169024/211261366-d337ece9-f764-49c2-9551-61fdcc01bb0d.png)  
4. Add the 'Bearer' prefix to the accesstoken in the header like this:  
![image](https://user-images.githubusercontent.com/52169024/211261484-842c5f76-6ec0-4843-a817-0944d9c9a866.png)  
5. Then put this curl in the cmd to call the api once again.  
![image](https://user-images.githubusercontent.com/52169024/211261562-3725ad95-050b-4140-a7b0-7b6f26f6044e.png)  

# Change password API:
Follow the above step to change password. New password must be different from the old one.  