### PR TITLE
Add cors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ db.sqlite3
 .idea/
 
 boilerplate/.env
+
+# Command alias
+**/Makefile

--- a/boilerplate/settings.py
+++ b/boilerplate/settings.py
@@ -32,35 +32,46 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+CORS_ALLOWED_ORIGINS = [
+    # TODO: Move allowed origin, secret keys, database host, port, etc. to environment variables 
+    # (instead of directly setting in this file) for easy configuring the project in other environments.
+    
+    # TODO: add cors allowed origin for the frontend. Currently, only allow the server to call itself.
+    "http://localhost:8000",
+]
 
 # Application definition
 
+# Keep this list ordered alphabetically.
 INSTALLED_APPS = [
+    'ckeditor',
+    'coreapi',
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'rest_framework',
-    'graphene_django',
-    'rest_framework_simplejwt',
     'drf_yasg',
-    'ckeditor',
-    'coreapi',
+    'graphene_django',
+    'rest_framework',
+    'rest_framework_simplejwt',
     # Apps
-    'job',
-    'advisors',
     'accounts',
+    'advisors',
+    'companies',
+    'job',
+    'schools',
     'students',
     'recruiters',
-    'companies',
-    'schools',
-    
 ]
 
 MIDDLEWARE = [
     # 'log_request_id.middleware.RequestIDMiddleware',
+    # Keep CORS middleware near the top as possible to apply it early and allow header manipulation
+    # Check out https://github.com/adamchainz/django-cors-headers#setup
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/boilerplate/settings.py
+++ b/boilerplate/settings.py
@@ -38,6 +38,7 @@ CORS_ALLOWED_ORIGINS = [
     
     # TODO: add cors allowed origin for the frontend. Currently, only allow the server to call itself.
     "http://localhost:8000",
+    "http://127.0.0.1:8000",
 ]
 
 # Application definition


### PR DESCRIPTION
Add cors

Use https://github.com/adamchainz/django-cors-headers to implement cors for the server. Currently, we only whitelist localhost:8000 (the URL the server will be hosted at).

Testing video:

https://user-images.githubusercontent.com/56032607/211731793-95e3bb83-fec1-41d1-95c4-aedf9320570d.mov


